### PR TITLE
The build in keyboard is enabled by default. When USBDeviceManager

### DIFF
--- a/HHKBAssistant/AppDelegate.h
+++ b/HHKBAssistant/AppDelegate.h
@@ -11,6 +11,7 @@
 #import "PreferencePaneWindowController.h"
 #import "XPCManager.h"
 #import "Constants.h"
+#import "PreferenceUtil.h"
 
 @interface AppDelegate : NSObject <NSApplicationDelegate, NSUserNotificationCenterDelegate> {
     NSStatusItem * statusItem;
@@ -23,5 +24,6 @@
 @property PreferencePaneWindowController *prefPaneWindowController;
 @property USBDeviceManager *usbManager;
 @property XPCManager *xpcManager;
+@property PreferenceUtil *prefUtil;
 
 @end

--- a/HHKBAssistant/PreferenceUtil.h
+++ b/HHKBAssistant/PreferenceUtil.h
@@ -14,6 +14,8 @@
 
 @property NSMutableDictionary* plistDic;
 @property NSString *plistPath;
+@property BOOL kbStatus;
+@property BOOL hasExternalKB;
 
 - (id)read:(NSString *)key;
 - (void)write;

--- a/HHKBAssistant/PreferenceUtil.m
+++ b/HHKBAssistant/PreferenceUtil.m
@@ -12,6 +12,8 @@
 
 @synthesize plistDic;
 @synthesize plistPath;
+@synthesize kbStatus;
+@synthesize hasExternalKB;
 
 #pragma mark basic function Methods
 - (NSMutableDictionary *)load {
@@ -128,6 +130,8 @@
     if (self = [super init]) {
         // init path
         plistPath = [[NSBundle mainBundle] pathForResource:PREFERENCE_NAME ofType:@"plist"];
+        kbStatus = BUILD_IN_KEYBOARD_ENABLE;
+        hasExternalKB = false;
         
         // init
         [self update];

--- a/HHKBAssistant/USBDeviceManager.h
+++ b/HHKBAssistant/USBDeviceManager.h
@@ -16,6 +16,7 @@
 #include "DataSourceDelegate.h"
 #include "XPCManager.h"
 #include "Constants.h"
+#include "PreferenceUtil.h"
 
 typedef struct MyPrivateData {
     io_object_t				notification;
@@ -36,6 +37,7 @@ typedef struct MyPrivateData {
 @property (nonatomic, assign) id<DataSourceDelegate>  delegate;
 // xpc manager
 @property XPCManager *xpcManager;
+@property PreferenceUtil *prefUtil;
 
 ///////////////////////////////////////////
 //// use to listen to usb device

--- a/HHKBAssistant/USBDeviceManager.m
+++ b/HHKBAssistant/USBDeviceManager.m
@@ -15,6 +15,7 @@
 @synthesize gRunLoop;
 @synthesize delegate;
 @synthesize xpcManager;
+@synthesize prefUtil;
 
 //////////////////////////////////////////////////
 // wrapper object-c method to c callback function
@@ -43,7 +44,8 @@ static void SignalHandler(int sigraised) {
     
     if (messageType == kIOMessageServiceIsTerminated) {
         //auto enable keyboard action when device is removed or not
-        [self autoEnOrDisableKeyboard:ENABLE_KEYBOARD_REQUEST];
+        [self autoEnOrDisableKeyboard:ENABLE_KEYBOARD_REQUEST kbSatus:BUILD_IN_KEYBOARD_ENABLE];
+        prefUtil.hasExternalKB = false;
         
         ///////////////////////////
         // voice out message
@@ -100,7 +102,8 @@ static void SignalHandler(int sigraised) {
                 // if hit, do action
                 
                 //auto disable keyboard action when device is removed or not
-                [self autoEnOrDisableKeyboard:DISABLE_KEYBOARD_REQUEST];
+                [self autoEnOrDisableKeyboard:DISABLE_KEYBOARD_REQUEST kbSatus:BUILD_IN_KEYBOARD_DISABLE];
+                prefUtil.hasExternalKB = true;
                 
                 ///////////////////////////
                 // voice in message
@@ -287,11 +290,12 @@ static void SignalHandler(int sigraised) {
     [[NSUserNotificationCenter defaultUserNotificationCenter] deliverNotification:notification];
 }
 
-- (void) autoEnOrDisableKeyboard:(char *)request{
+- (void) autoEnOrDisableKeyboard:(char *)request kbSatus:(BOOL)kbStatus{
     NSInteger flag = [delegate isAutoDisable];
     if (flag == NSOnState) {
         // only do auto action when flag is on
         [xpcManager sendRequest:request];
+        prefUtil.kbStatus = kbStatus;
     }
 }
 
@@ -303,6 +307,7 @@ static void SignalHandler(int sigraised) {
 - (id) init {
     if (self = [super init]) {
         xpcManager = [XPCManager getSharedInstance];
+        prefUtil = [PreferenceUtil getSharedInstance];
     }
     return self;
 }


### PR DESCRIPTION
handles keyboard plugged in/out event, it also reset the kbStatus.
Hide the enable/disable keyboard menu item when there is no external
keyboard.

hi. This commit is a workaround for build in keyboard status detection. We first assume the build kb is enabled by default, we can reset the kbStatus when there's keyboard plugged in/out event.

This commit also hide the enable/disable menu when there is no external keyboard. I wanted to disable the menu, but the api is only available by 10.10.

I think this app has something more to polish. Hope we can get a better version.
